### PR TITLE
chore(deps): update springdoc-openapi-starter-webmvc-ui from 2.7.0 to…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.7.0</version>
+			<version>2.8.3</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
… 2.8.3

- Upgrade springdoc-openapi-starter-webmvc-ui dependency to latest stable version
- Improve API documentation rendering and performance
- Include security fixes from newer version

Testing:
- Verified Swagger UI loads correctly
- Confirmed all endpoints are properly documented
- Validated schema generation
- Integration tests passing

Closes #7