### PR TITLE
release(v1.0.0): Spring Boot 4.0.4 and dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,32 +5,22 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2025-12-31
+## [1.0.0] - 2026-03-31
 
 ### Changed
-- **BREAKING**: Migración completa de librerías PDF de `com.lowagie.text` a `org.openpdf.text`
-  - Actualización de OpenPDF: 2.2.3 → 3.0.0
-  - Eliminación de dependencias obsoletas de iText
-  - Refactorización de imports y clases PDF
-- **deps**: Actualización de Spring Boot: 3.5.3 → 3.5.8
-- **deps**: Actualización de Java: 24 → 25
-- **deps**: Actualización de SpringDoc OpenAPI: 2.8.9 → 2.8.10
-- **refactor**: Simplificación del constructor usando Lombok @RequiredArgsConstructor
-- **config**: Mejoras en configuración de actuator health checks
-- **config**: Configuración de management endpoints access control
+- **BREAKING**: Actualización de Spring Boot 3.5.8 → 4.0.4
+- **deps**: Actualización de Spring Cloud: 2025.0.0 → 2025.1.0
+- **deps**: Actualización de SpringDoc OpenAPI: 2.8.10 → 3.0.2
+- **deps**: Actualización de OpenPDF: 3.0.0 → 3.0.3
+- **deps**: Actualización de commons-lang3: 3.18.0 → 3.20.0
+- **config**: Eliminación de configuración executable en spring-boot-maven-plugin
+- **refactor**: ConsumoContextDto y DatoConsumoDto usan @Getter/@Setter/@NoArgsConstructor/@AllArgsConstructor
 
 ### Added
-- **config**: Configuración mejorada de actuator health checks
-- **config**: Configuración de management endpoints con acceso controlado
-- **infra**: Actualización de Docker images para JDK 25
-- **ci**: Actualización del workflow de GitHub Actions para JDK 25
-
-### Fixed
-- **perf**: Optimización en la generación de PDFs con la nueva librería OpenPDF
-- **deps**: Eliminación de dependencias redundantes de iText
+- **deps**: Nueva dependencia commons-fileupload 1.6.0
 
 ### Security
-- **deps**: Actualización a las últimas versiones estables de dependencias
+- Actualización a últimas versiones estables de dependencias
 
 ## [Unreleased]
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Report Service
 
 [![Java](https://img.shields.io/badge/Java-25-orange.svg)](https://www.oracle.com/java/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.8-brightgreen.svg)](https://spring.io/projects/spring-boot)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
-[![OpenPDF](https://img.shields.io/badge/OpenPDF-3.0.0-red.svg)](https://github.com/LibrePDF/OpenPDF)
-[![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-2.8.10-blue.svg)](https://springdoc.org/)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.4-brightgreen.svg)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-blue.svg)](https://spring.io/projects/spring-cloud)
+[![OpenPDF](https://img.shields.io/badge/OpenPDF-3.0.3-red.svg)](https://github.com/LibrePDF/OpenPDF)
+[![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-3.0.2-blue.svg)](https://springdoc.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8+-red.svg)](https://maven.apache.org/)
 
 Servicio de generación de reportes para el sistema de gestión de agua.
@@ -26,13 +26,13 @@ Este servicio es responsable de generar reportes y liquidaciones en formato PDF 
 ## Tecnologías
 
 - Java 25
-- Spring Boot 3.5.8
-- Spring Cloud 2025.0.0
-- OpenPDF 3.0.0 (migrado desde iText)
+- Spring Boot 4.0.4
+- Spring Cloud 2025.1.0
+- OpenPDF 3.0.3 (migrado desde iText)
 - Spring Cloud Netflix Eureka Client
 - Spring Cloud OpenFeign
 - Spring Boot Mail
-- SpringDoc OpenAPI 2.8.10
+- SpringDoc OpenAPI 3.0.2
 - Lombok para reducción de boilerplate code
 - Caffeine para caching
 - Consul para service discovery

--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,18 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.8</version>
+		<version>4.0.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sauce.agua.report</groupId>
 	<artifactId>report-service</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>1.0.0</version>
 	<name>SAUCE.agua.report-service</name>
 	<description>sauce.agua.report-service</description>
 
 	<properties>
 		<java.version>25</java.version>
-		<spring-cloud.version>2025.0.0</spring-cloud.version>
+		<spring-cloud.version>2025.1.0</spring-cloud.version>
 		<sonar.organization>sauce-services</sonar.organization>
 		<sonar.projectKey>SAUCE-services_SAUCE.agua.report-service</sonar.projectKey>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.8.10</version>
+			<version>3.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>com.github.librepdf</groupId>
 			<artifactId>openpdf</artifactId>
-			<version>3.0.0</version>
+			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -90,7 +90,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.18.0</version>
+				<version>3.20.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -98,6 +98,11 @@
 				<version>${spring-cloud.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>commons-fileupload</groupId>
+				<artifactId>commons-fileupload</artifactId>
+				<version>1.6.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -108,9 +113,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<executable>true</executable>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/sauce/agua/report/model/dto/facade/ConsumoContextDto.java
+++ b/src/main/java/com/sauce/agua/report/model/dto/facade/ConsumoContextDto.java
@@ -1,13 +1,15 @@
 package com.sauce.agua.report.model.dto.facade;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.time.OffsetDateTime;
 
-@Data
+@Getter
+@Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ConsumoContextDto {
 
     private Long clienteId;

--- a/src/main/java/com/sauce/agua/report/model/dto/facade/DatoConsumoDto.java
+++ b/src/main/java/com/sauce/agua/report/model/dto/facade/DatoConsumoDto.java
@@ -1,13 +1,15 @@
 package com.sauce.agua.report.model.dto.facade;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.time.OffsetDateTime;
 
-@Data
+@Getter
+@Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class DatoConsumoDto {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")


### PR DESCRIPTION
Closes #24

## Descripción

Release v1.0.0 con actualización major de Spring Boot 3.x a 4.x y actualización de todas las dependencias del proyecto.

## Cambios Realizados

- **Spring Boot**: 3.5.8 → 4.0.4 (actualización major)
- **Spring Cloud**: 2025.0.0 → 2025.1.0
- **SpringDoc OpenAPI**: 2.8.10 → 3.0.2
- **OpenPDF**: 3.0.0 → 3.0.3
- **commons-lang3**: 3.18.0 → 3.20.0
- **Nueva dependencia**: commons-fileupload 1.6.0
- **Eliminación**: Configuración executable en spring-boot-maven-plugin
- **Versión del proyecto**: 0.0.1-SNAPSHOT → 1.0.0
- **Refactorización DTOs**: Cambio de `@Data` a `@Getter/@Setter/@NoArgsConstructor/@AllArgsConstructor`
- **Documentación**: Actualización de CHANGELOG.md y README.md

## Verificación

- [ ] Compilación exitosa con `mvn clean install`
- [ ] Pruebas unitarias passing
- [ ] Verificación de compatibilidad con Spring Boot 4.0
- [ ] Documentación actualizada
